### PR TITLE
Remove htmlspecialchars on Location page title

### DIFF
--- a/includes/controller/locations_controller.php
+++ b/includes/controller/locations_controller.php
@@ -53,7 +53,7 @@ function location_controller(): array
     $shiftCalendarRenderer = shiftCalendarRendererByShiftFilter($shiftsFilter);
 
     return [
-        htmlspecialchars($location->name),
+        $location->name,
         location_view($location, $shiftsFilterRenderer, $shiftCalendarRenderer),
     ];
 }


### PR DESCRIPTION
htmlspecialchars is not needed here since the <title> tag doesn't interpret HTML, only text. Twig takes care of < and > for us anyway.

I'll hunt down the critter type equivalent tomorrow.