### PR TITLE
Fix #50: Warning on cascading location delete

### DIFF
--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -301,7 +301,32 @@ ready(() => {
         return;
       }
       event.preventDefault();
-
+      const modalFooterHtml =
+        `
+          <div class="modal-footer">
+            <button type="button" class="${element.className}"
+              autofocus
+              title="${element.title}" data-submit="">
+                ${element.dataset.confirm_button_text ?? element.innerHTML}
+            </button>
+          </div>
+        `
+      const doubleConfirmButtonHtml =
+        `
+          <div class="modal-footer collapse show double-confirm-modal">
+            <button type="button" type="button" class="${element.className}"
+              data-bs-toggle="collapse" data-bs-target=".double-confirm-modal"
+              aria-expanded="false" aria-controls="double-confirm-modal">
+                ${element.dataset.confirm_button_text ?? element.innerHTML}
+            </button>
+          </div>
+          <div class="collapse double-confirm-modal">
+            <div class="modal-body">
+              <p>${element.dataset.double_confirm_submit_text}</p>
+            </div>
+            ${modalFooterHtml}
+          </div>
+          `
       document.getElementById('confirmation-modal')?.remove();
       document.body.insertAdjacentHTML(
         'beforeend',
@@ -316,13 +341,7 @@ ready(() => {
                 <div class="modal-body${element.dataset.confirm_submit_text ? '' : ' d-none'}">
                   <p>${element.dataset.confirm_submit_text ?? ''}</p>
                 </div>
-                <div class="modal-footer">
-                  <button type="button" class="${element.className}"
-                    autofocus
-                    title="${element.title}" data-submit="">
-                    ${element.dataset.confirm_button_text ?? element.innerHTML}
-                  </button>
-                </div>
+                ${element.dataset.double_confirm_submit_text ? doubleConfirmButtonHtml : modalFooterHtml}
               </div>
             </div>
           </div>

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -744,6 +744,10 @@ msgstr "Edit location"
 msgid "location.delete.title"
 msgstr "Delete location \"%s\""
 
+msgid "location.delete.double_confirm"
+msgstr "Location has %d shifts still assigned to it. "
+"Are you sure you want to delete it?"
+
 msgid "shifttype.shifttypes"
 msgstr "Shift types"
 

--- a/resources/views/admin/locations/index.twig
+++ b/resources/views/admin/locations/index.twig
@@ -62,13 +62,21 @@
                                             <form method="post" class="ps-1">
                                                 {{ csrf() }}
                                                 {{ f.hidden('id', location.id) }}
-                                                {{ f.delete(null, {
-                                                    'size': 'sm',
-                                                    'confirm_title': __('location.delete.title', [location.name|e]),
-                                                    'confirm_button_text': __('form.delete'),
-                                                }) }}
+                                                {% if location.shifts_count > 0 %}
+                                                    {{ f.delete(null, {
+                                                        'size': 'sm',
+                                                        'confirm_title': __('location.delete.title', [location.name|e]),
+                                                        'confirm_button_text': __('form.delete'),
+                                                        'double_confirm_text': __('location.delete.double_confirm', [location.shifts_count]),
+                                                    }) }}
+                                                {% else %}
+                                                    {{ f.delete(null, {
+                                                        'size': 'sm',
+                                                        'confirm_title': __('location.delete.title', [location.name|e]),
+                                                        'confirm_button_text': __('form.delete'),
+                                                    }) }}
+                                                {% endif %}
                                             </form>
-
                                         </div>
                                     </td>
                                 </tr>

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -277,6 +277,8 @@ Renders a button.
                                     Must be a Bootstrap icon class without prefix, such as "info" or "check".
 @param {string} [opt.confirm_title] - Optional value for the confirmation title.
 @param {string} [opt.confirm_text] - Optional value for the confirmation text.
+@param {string} [opt.double_confirm_text] - Optional value for the double confirmation text.
+                                            THis will transform the confirmation to double confirmation
 @param {dictionary} [opt.attr] - Optional value for additional attributes like data fields.
 #}
 {% macro button(label, opt) %}
@@ -291,6 +293,7 @@ Renders a button.
         {%- if opt.value is defined or opt.name is defined %} value="{{ opt.value|default('1') }}"{% endif -%}
         {%- if opt.confirm_title is defined %} data-confirm_submit_title="{{ opt.confirm_title }}"{% endif -%}
         {%- if opt.confirm_text is defined %} data-confirm_submit_text="{{ opt.confirm_text }}"{% endif -%}
+        {%- if opt.double_confirm_text is defined %} data-double_confirm_submit_text="{{ opt.double_confirm_text }}"{% endif -%}
         {%- if opt.confirm_button_text is defined %}
             data-confirm_button_text="{{ icon_left ~ ' ' ~ opt.confirm_button_text ~ ' ' ~ icon_right }}"
         {%- endif -%}


### PR DESCRIPTION
* Add double_confirm_text to buttons which causes the button to ask for additional confirmation when pressed.
* Add use of double confirm in location delete form when it has shifts

Preview of how it works with shifts and without shifts:
![Peek 2025-07-13 14-06](https://github.com/user-attachments/assets/6cfb4927-5912-4298-b7fb-242641303646)

