### PR TITLE
Feature/44 when critter opens shift nothing shows up

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,9 +1,9 @@
 # Engelsystem PHP FPM/Nginx development image including Xdebug
 FROM php:8.2-fpm-alpine AS es_base
 WORKDIR /var/www
-RUN apk add --no-cache icu-dev linux-headers $PHPIZE_DEPS && \
+RUN apk add --no-cache icu-dev linux-headers $PHPIZE_DEPS libzip-dev libpng-dev && \
     pecl install pcov xdebug && \
-    docker-php-ext-install intl pdo_mysql && \
+    docker-php-ext-install intl pdo_mysql gd zip && \
     docker-php-ext-enable pcov xdebug
 RUN echo -e "xdebug.mode=debug\nxdebug.discover_client_host=1\n" >> /usr/local/etc/php/conf.d/xdebug.ini
 

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -6,6 +6,7 @@ if (!is_readable(__DIR__ . '/../vendor/autoload.php')) {
     exit(1);
 }
 
+require __DIR__ . '/includes.php';
 // Include composer autoloader
 // phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 $loader = require __DIR__ . '/../vendor/autoload.php';

--- a/includes/model/ShiftsFilter.php
+++ b/includes/model/ShiftsFilter.php
@@ -32,7 +32,10 @@ class ShiftsFilter
     private $filled;
 
     /** @var int[] */
-    private $types;
+    private $selectedTypes;
+
+    /** @var int[] */
+    private $selectedLocations;
 
     /** @var int unix timestamp */
     private $startTime = null;
@@ -44,12 +47,14 @@ class ShiftsFilter
      * ShiftsFilter constructor.
      *
      * @param bool  $user_shifts_admin
-     * @param int[] $locations
-     * @param int[] $angelTypes
+     * @param int[] $allLocations
+     * @param int[] $types
+     * @param int[] $ownTypes
      */
-    public function __construct($user_shifts_admin = false, private $locations = [], $angelTypes = [])
+    public function __construct($user_shifts_admin = false, private $locations = [], private $types = [], $ownTypes = [])
     {
-        $this->types = $angelTypes;
+        $this->selectedTypes = $ownTypes;
+        $this->selectedLocations = $locations;
 
         $this->filled = [
             ShiftsFilter::FILLED_FREE,
@@ -65,11 +70,18 @@ class ShiftsFilter
      */
     public function sessionExport()
     {
+        // remove nonexisting locations
+        $this->selectedLocations = array_intersect($this->locations, $this->selectedLocations);
+        // remove non-existing types
+        $this->selectedTypes = array_intersect($this->types, $this->selectedTypes);
+
         return [
             'userShiftsAdmin' => $this->userShiftsAdmin,
             'filled'          => $this->filled,
-            'locations'       => $this->locations,
-            'types'           => $this->types,
+            'locations'       => $this->selectedLocations,
+            'all_locations'   => $this->locations,
+            'types'           => $this->selectedTypes,
+            'all_types'       => $this->types,
             'startTime'       => $this->startTime,
             'endTime'         => $this->endTime,
         ];
@@ -82,10 +94,50 @@ class ShiftsFilter
     {
         $this->userShiftsAdmin = $data['userShiftsAdmin'] ?? false;
         $this->filled = $data['filled'] ?? [];
-        $this->locations = $data['locations'] ?? [];
-        $this->types = $data['types'] ?? [];
+        $this->selectedLocations = $data['locations'] ?? [];
+        $this->locations = $data['all_locations'] ?? $this->selectedLocations;
+        $this->selectedTypes = $data['types'] ?? [];
+        $this->types = $data['all_types'] ?? $this->selectedTypes;
         $this->startTime = $data['startTime'] ?? null;
         $this->endTime = $data['endTime'] ?? null;
+
+        $this->filled = array_map('intval', $this->filled);
+        $this->selectedLocations = array_map('intval', $this->selectedLocations);
+        $this->locations = array_map('intval', $this->locations);
+        $this->selectedTypes = array_map('intval', $this->selectedTypes);
+        $this->types = array_map('intval', $this->types);
+    }
+
+    /**
+     * Update the location list. Add any new locations to the selectedLocations
+     * @param array $allLocations
+     * @return void
+     */
+    public function updateLocations($allLocations)
+    {
+        $diff = array_diff($allLocations, $this->locations);
+        $this->locations = $allLocations;
+        if (count($diff) > 0) {
+            $newDiffLocations = array_diff($diff, $this->selectedLocations);
+            $this->selectedLocations = array_merge($this->selectedLocations, $newDiffLocations);
+        }
+    }
+
+    /**
+     * Update the types list. Add new types if they are own to the selectedTypes
+     * @param mixed $allTypes
+     * @return void
+     */
+    public function updateTypes($allTypes, $ownTypes)
+    {
+        $diff = array_diff($allTypes, $this->types);
+        $this->types = $allTypes;
+        if (count($diff) > 0) {
+            // find new types that are own types
+            $newOwnTypes = array_intersect($ownTypes, $diff);
+            $newDiffTypes = array_diff($newOwnTypes, $this->selectedTypes);
+            $this->selectedTypes = array_merge($this->selectedTypes, $newDiffTypes);
+        }
     }
 
     /**
@@ -146,18 +198,18 @@ class ShiftsFilter
      */
     public function getTypes()
     {
-        if (count($this->types) == 0) {
+        if (count($this->selectedTypes) == 0) {
             return [0];
         }
-        return $this->types;
+        return $this->selectedTypes;
     }
 
     /**
      * @param int[] $types
      */
-    public function setTypes($types)
+    public function setTypes($selectedTypes)
     {
-        $this->types = $types;
+        $this->selectedTypes = array_map('intval', $selectedTypes);
     }
 
     /**
@@ -165,10 +217,10 @@ class ShiftsFilter
      */
     public function getLocations()
     {
-        if (count($this->locations) == 0) {
+        if (count($this->selectedLocations) == 0) {
             return [0];
         }
-        return $this->locations;
+        return $this->selectedLocations;
     }
 
     /**
@@ -176,7 +228,7 @@ class ShiftsFilter
      */
     public function setLocations($locations)
     {
-        $this->locations = $locations;
+        $this->selectedLocations = array_map('intval', $locations);
     }
 
     /**
@@ -200,6 +252,6 @@ class ShiftsFilter
      */
     public function setFilled($filled)
     {
-        $this->filled = $filled;
+        $this->filled = array_map('intval', $filled);
     }
 }

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -319,7 +319,8 @@ function view_user_shifts()
                     $locations,
                     $shiftsFilter->getLocations(),
                     'locations',
-                    icon('pin-map-fill') . __('Locations')
+                    icon('pin-map-fill') . __('Locations'),
+                    askForAttention: $shiftCalendarRenderer->hasShiftsToDisplay() == false
                 ),
                 'start_select'  => html_select_key(
                     'start_day',
@@ -343,7 +344,8 @@ function view_user_shifts()
                     . ' <small><span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="'
                     . __('The tasks shown here are influenced by the critter types you joined already!')
                     . '"></span></small>',
-                    $ownAngelTypes
+                    $ownAngelTypes,
+                    askForAttention: $shiftCalendarRenderer->hasShiftsToDisplay() == false
                 ),
                 'filled_select' => make_select(
                     $filled,
@@ -404,11 +406,15 @@ function ical_hint()
  * @param int[]  $ownSelect
  * @return string
  */
-function make_select($items, $selected, $name, $title = null, $ownSelect = [])
+function make_select($items, $selected, $name, $title = null, $ownSelect = [], $askForAttention = false)
 {
     $html = '';
+    $extraClass = '';
+    if ($askForAttention) {
+        $extraClass = 'attention-ring';
+    }
     if (isset($title)) {
-        $html .= '<h4>' . $title . '</h4>' . "\n";
+        $html .= '<h4 class="' . $extraClass . '">' . $title . '</h4>' . "\n";
     }
 
     $buttons = [

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -258,15 +258,22 @@ function view_user_shifts()
     foreach ($userAngelTypes as $type) {
         $ownAngelTypes[] = $type->angel_type_id;
     }
-
+    $location_ids = $locations->pluck('id')->toArray();
+    $type_ids = array_column($types, 'id');
     if (!$session->has('shifts-filter')) {
-        $location_ids = $locations->pluck('id')->toArray();
-        $shiftsFilter = new ShiftsFilter(auth()->can('user_shifts_admin'), $location_ids, $ownAngelTypes);
+        $shiftsFilter = new ShiftsFilter(
+            auth()->can('user_shifts_admin'),
+            $location_ids,
+            $type_ids,
+            $ownAngelTypes
+        );
         $session->set('shifts-filter', $shiftsFilter->sessionExport());
     }
 
     $shiftsFilter = new ShiftsFilter();
     $shiftsFilter->sessionImport($session->get('shifts-filter'));
+    $shiftsFilter->updateLocations($location_ids);
+    $shiftsFilter->updateTypes($type_ids, $ownAngelTypes);
     update_ShiftsFilter($shiftsFilter, auth()->can('user_shifts_admin'), $days);
     $session->set('shifts-filter', $shiftsFilter->sessionExport());
 

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -352,4 +352,9 @@ class ShiftCalendarRenderer
             badge(__('Shift is running/ended or you have not arrived'), 'secondary'),
         ]);
     }
+
+    public function hasShiftsToDisplay(): bool
+    {
+        return count($this->lanes) > 0;
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>
+        <testsuite name="includes">
+            <directory>tests/Unit/includes</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -437,3 +437,25 @@ input[type='number'] {
 input[type='text']:invalid {
   color: map.get($theme-colors, 'danger');
 }
+
+.attention-ring::before {
+    display: block;
+    content: "";
+    pointer-events: none;
+    border-radius: 50%;
+    border: 10px solid red;
+    opacity: 0;
+    position: absolute;
+    animation: attention 1s cubic-bezier(0,0,.2,1) 2;
+    animation-delay: 1s;
+}
+@keyframes attention {
+  0%  {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(5); /* multiple of the initial size */
+    opacity: 0;
+  }
+}

--- a/tests/Unit/includes/ShiftFilterTest.php
+++ b/tests/Unit/includes/ShiftFilterTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\includes;
+
+use Engelsystem\ShiftsFilter;
+use Engelsystem\Test\Unit\TestCase;
+
+class ShiftsFilterTest extends TestCase
+{
+    /**
+     * @covers \Engelsystem\ShiftsFilter::sessionImport
+     */
+    public function testImportsLegacySession(): void
+    {
+        $session = array (
+            'userShiftsAdmin' => false,
+            'filled' => array ( 0 => '0', ),
+            'locations' => array ( 0 => '91', ),
+            'types' => array ( 0 => '1', 1 => '2', 2 => '3', ),
+            'startTime' => 1752684300,
+            'endTime' => 1752770700,
+        );
+
+        $filter = new ShiftsFilter();
+        $filter->sessionImport($session);
+
+        $this->assertEqualsCanonicalizing($session['types'], $filter->getTypes());
+        $this->assertEqualsCanonicalizing($session['locations'], $filter->getLocations());
+
+        $saved_session = $filter->sessionExport();
+
+        $expected_types = array(1, 2, 3);
+        $expected_locations = array(91);
+
+        $this->assertEqualsCanonicalizing($expected_types, $saved_session['types']);
+        $this->assertEqualsCanonicalizing($expected_locations, $saved_session['locations']);
+        $this->assertEqualsCanonicalizing($expected_types, $saved_session['all_types']);
+        $this->assertEqualsCanonicalizing($expected_locations, $saved_session['all_locations']);
+    }
+
+    /**
+     * @covers \Engelsystem\ShiftsFilter::updateLocations
+     * @covers \Engelsystem\ShiftsFilter::updateTypes
+     */
+    public function testUpdatesLegacySessionWithAdditional(): void
+    {
+        $session = array (
+            'userShiftsAdmin' => false,
+            'filled' => array ( 0 => '0', ),
+            'locations' => array ( 0 => '91', ),
+            'types' => array ( 0 => '1', 1 => '2', 2 => '3', ),
+            'startTime' => 1752684300,
+            'endTime' => 1752770700,
+        );
+
+        $filter = new ShiftsFilter();
+        $filter->sessionImport($session);
+        $location_ids = array(91, 92);
+        $type_ids = array(1, 2, 3, 10, 11);
+        $own_type_ids = array(1, 2, 3, 10);
+
+        $filter->updateLocations($location_ids);
+        $filter->updateTypes($type_ids, $own_type_ids);
+
+        $this->assertEqualsCanonicalizing($own_type_ids, $filter->getTypes());
+        $this->assertEqualsCanonicalizing($location_ids, $filter->getLocations());
+
+        $saved_session = $filter->sessionExport();
+
+        $this->assertEqualsCanonicalizing($own_type_ids, $saved_session['types']);
+        $this->assertEqualsCanonicalizing($location_ids, $saved_session['locations']);
+        $this->assertEqualsCanonicalizing($type_ids, $saved_session['all_types']);
+        $this->assertEqualsCanonicalizing($location_ids, $saved_session['all_locations']);
+    }
+
+    /**
+     * @covers \Engelsystem\ShiftsFilter::updateLocations
+     * @covers \Engelsystem\ShiftsFilter::updateTypes
+     */
+    public function testUpdatesLegacySessionWithNew(): void
+    {
+        $session = array (
+            'userShiftsAdmin' => false,
+            'filled' => array ( 0 => '0', ),
+            'locations' => array ( 0 => '91', ),
+            'types' => array ( 0 => '1', 1 => '2', 2 => '3', ),
+            'startTime' => 1752684300,
+            'endTime' => 1752770700,
+        );
+
+        $filter = new ShiftsFilter();
+        $filter->sessionImport($session);
+        $location_ids = array(92);
+        $type_ids = array(10, 11);
+        $own_type_ids = array(10);
+
+        $expect_locations = array(91, 92);
+        $expect_types = array(1, 2, 3, 10);
+
+        $filter->updateLocations($location_ids);
+        $filter->updateTypes($type_ids, $own_type_ids);
+
+        $this->assertEqualsCanonicalizing($expect_types, $filter->getTypes());
+        $this->assertEqualsCanonicalizing($expect_locations, $filter->getLocations());
+
+        $saved_session = $filter->sessionExport();
+        // during export non-existing IDs are cleaned up
+        $this->assertEqualsCanonicalizing($own_type_ids, $saved_session['types']);
+        $this->assertEqualsCanonicalizing($location_ids, $saved_session['locations']);
+        $this->assertEqualsCanonicalizing($type_ids, $saved_session['all_types']);
+        $this->assertEqualsCanonicalizing($location_ids, $saved_session['all_locations']);
+    }
+
+
+        /**
+     * @covers \Engelsystem\ShiftsFilter::updateLocations
+     * @covers \Engelsystem\ShiftsFilter::updateTypes
+     */
+    public function testUpdatesSessionWithoutUnselected(): void
+    {
+        $session = array (
+            'userShiftsAdmin' => false,
+            'filled' => array ( 0 => 0, ),
+            'locations' => array ( 0 => 91, ),
+            'all_locations' => array ( 0 => 91, 1 => 92, ),
+            'types' => array ( 0 => 1, 1 => 2, 2 => 5, ),
+            'all_types' => array ( 0 => 1, 1 => 2, 2 => 3, 3 => 4, 4 => 5, ),
+            'startTime' => 1752684300,
+            'endTime' => 1752770700,
+        );
+
+        $filter = new ShiftsFilter();
+        $filter->sessionImport($session);
+        $location_ids = array(91, 92, 100);
+        $type_ids = array(1, 2, 3, 4, 5, 10, 11);
+        $own_type_ids = array(1, 2, 3, 4, 10);
+
+        $expect_locations = array(91, 100);
+        $expect_types = array(1, 2, 5, 10);
+
+        $filter->updateLocations($location_ids);
+        $filter->updateTypes($type_ids, $own_type_ids);
+
+        $this->assertEqualsCanonicalizing($expect_types, $filter->getTypes());
+        $this->assertEqualsCanonicalizing($expect_locations, $filter->getLocations());
+
+        $saved_session = $filter->sessionExport();
+        // during export non-existing IDs are cleaned up
+        $this->assertEqualsCanonicalizing($expect_types, $saved_session['types']);
+        $this->assertEqualsCanonicalizing($expect_locations, $saved_session['locations']);
+        $this->assertEqualsCanonicalizing($type_ids, $saved_session['all_types']);
+        $this->assertEqualsCanonicalizing($location_ids, $saved_session['all_locations']);
+    }
+}


### PR DESCRIPTION
3 things done in this PR. I can split them into separate ones if needed or drop them:

1. Dev docker deps for zip and gd and installing them
2. ShiftsFilter update with UnitTests
    - ShiftsFilter now holds all known types and locations so we know when a new one is added
    - Changed use of $types and $location to hold the all known ones
    - selectedTypes and selectedLocations hold the selection done by user
    - When updating with new location if it was not in $locations, add the new one to $selectedLocations
    - Similar for $selectedTypes, but we only add new own types
    - This will not update $selectedTypes with a new type if the new type was just assigned to the user - **should we consider this?**
3. Animation to catch user's attention to change filters if no shift's found. - Not sure about this one, but thought if all else fails it'll be good to direct user's eyes towards something helpful

![Peek 2025-07-16 21-50](https://github.com/user-attachments/assets/05b5a6c8-ba55-4bfe-a060-52ce3b6c006d)
