### PR TITLE
Fix #19: Make shift legend sticky so it's always visible

### DIFF
--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -145,7 +145,7 @@ class ShiftCalendarRenderer
             div('shift-calendar table-responsive', [
                 $this->renderTimeLane(),
                 $this->renderShiftLanes(),
-            ]) . $this->renderLegend();
+            ]);
     }
 
     /**
@@ -344,7 +344,7 @@ class ShiftCalendarRenderer
      */
     private function renderLegend()
     {
-        return div('legend mt-3', [
+        return div('legend sticky-legend mt-3', [
             badge(__('Your shift'), 'primary'),
             badge(__('Help needed'), 'danger'),
             badge(__('Other critter type needed / collides with my shifts'), 'warning'),

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -212,6 +212,13 @@ table .border-bottom {
   display: block;
 }
 
+.sticky-legend {
+  position: sticky;
+  top: calc(40px + $navbar-padding-y * 2 + var(--#{$prefix}border-width));
+  z-index: $zindex-sticky;
+  height: 25px;
+}
+
 .shift-calendar {
   display: flex;
   flex-direction: row;
@@ -228,7 +235,7 @@ table .border-bottom {
 
     .header {
       position: sticky;
-      top: calc(40px + $navbar-padding-y * 2 + var(--#{$prefix}border-width));
+      top: calc(60px + $navbar-padding-y * 2 + var(--#{$prefix}border-width));
       z-index: $zindex-sticky;
       border-bottom: 1px solid $table-border-color;
       height: 30px;


### PR DESCRIPTION
Remove bottom legend since top is sticky
Move table header down so it's visible bellow the legend
![Peek 2025-08-09 12-55](https://github.com/user-attachments/assets/de0effbd-8695-42d2-a669-9ba110f4b65d)
