### PR TITLE
Light text on all alert boxes except warning

### DIFF
--- a/resources/assets/themes/theme21.scss
+++ b/resources/assets/themes/theme21.scss
@@ -344,6 +344,7 @@ table.table.table-striped.data {
   backdrop-filter: blur(32px);
   border: unset;
   box-shadow: 0 5px 5px 5px rgba(0, 0, 0, 0.2), inset -1px -1px rgba(181, 181, 181, 0.55);
+  color: #fff;
 }
 
 .alert-info {
@@ -356,6 +357,10 @@ table.table.table-striped.data {
 
 .alert-danger {
   background-color: transparentize(#b90000, 0.5);
+}
+
+.alert-warning, .alert-warning a {
+  color: #000;
 }
 
 #buildup_start,


### PR DESCRIPTION
Before:
<img width="1280" height="281" alt="image" src="https://github.com/user-attachments/assets/1bc10ee6-16ff-4ed2-a4e5-64acee490f14" />

After:
<img width="1327" height="177" alt="image" src="https://github.com/user-attachments/assets/41e76496-4047-4988-967d-439b3cf094b3" />
