### PR TITLE
Fix #58 - Add weekday to shift search table

### DIFF
--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -255,14 +255,18 @@ class ShiftCalendarRenderer
                 return div($class . ' day');
             }
             return div($class . ' day', [
-                $time->format(__('m-d')) . '<br>' . $time->format(__('H:i')),
+                __($time->format('D')) . ', '
+                . $time->format(__('m-d')) . '<br>'
+                . $time->format(__('H:i')),
             ]);
         } elseif ($time->isStartOfHour()) {
             if (!$label) {
                 return div($class . ' hour');
             }
             return div($class . ' hour', [
-                $time->format(__('m-d')) . '<br>' . $time->format(__('H:i')),
+                __($time->format('D')) . ', '
+                . $time->format(__('m-d')) . '<br>'
+                . $time->format(__('H:i')),
             ]);
         }
         return div($class);

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -2130,3 +2130,24 @@ msgstr "Use the button to automatically retrieve your Badge ID"
 
 msgid "settings.profile.badge_number_update"
 msgstr "Update"
+
+msgid "Mon"
+msgstr "Mo"
+
+msgid "Tue"
+msgstr "Di"
+
+msgid "Wed"
+msgstr "Mi"
+
+msgid "Thu"
+msgstr "Do"
+
+msgid "Fri"
+msgstr "Fr"
+
+msgid "Sat"
+msgstr "Sa"
+
+msgid "Sun"
+msgstr "So"


### PR DESCRIPTION
This is more of a quick fix, a proper would be a unified way to format all dates depending on selected language.

If we want to do it properly, we'd need a global format function that would take into account currently selected language for weekday names or month names.

This is why for now - just add weekday translations from English to German.
<img width="127" height="531" alt="image" src="https://github.com/user-attachments/assets/738024c2-edec-45ec-8b30-d50524395a04" />
<img width="130" height="466" alt="image" src="https://github.com/user-attachments/assets/e2ec9eba-26a6-4367-91ec-6f44c19c4195" />
