### PR TITLE
Fix minor things

### DIFF
--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -601,7 +601,7 @@ function AngelType_view(
     ShiftCalendarRenderer $shiftCalendarRenderer,
     $tab
 ) {
-    $back = button(url('/angeltypes'), icon('chevron-left'), 'btn-sm', '', __('general.back'));
+    $back = button(url('/crittertypes'), icon('chevron-left'), 'btn-sm', '', __('general.back'));
     $add = (($admin_angeltypes || $admin_user_angeltypes) ? button(
         url('/user-angeltypes', ['action' => 'add', 'angeltype_id' => $angeltype->id]),
         icon('plus-lg'),

--- a/resources/views/admin/user-certifications/modals.twig
+++ b/resources/views/admin/user-certifications/modals.twig
@@ -151,7 +151,7 @@
                             {{ __('user_certifications.note') }}
                             <span class="text-danger">*</span>
                         </label>
-                        <textarea class="form-control" id="addNoteText" name="note" rows="4"
+                        <textarea class="form-control" id="addNoteText" name="note" rows="4" autocomplete="off"
                                   placeholder="{{ __('user_certifications.note_placeholder') }}" required></textarea>
                         <div class="form-text">{{ __('user_certifications.note.help') }}</div>
                     </div>

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -157,7 +157,7 @@ Also adds buttons to increment / decrement the value.
                 {{ _self.info(opt.info) }}
             {% endif %}
         {%- endif %}
-        <textarea class="form-control" id="{{ name }}" name="{{ name }}"
+        <textarea class="form-control" id="{{ name }}" name="{{ name }}" autocomplete="off"
                     {%- if opt.required|default(false) %} required{%- endif -%}
             {%- if opt.rows|default(0) %} rows="{{ opt.rows }}"{%- endif -%}
                 >{{ opt.value|default('') }}</textarea>

--- a/resources/views/pages/departments/create.twig
+++ b/resources/views/pages/departments/create.twig
@@ -17,7 +17,7 @@
 
                     <div class="mb-3">
                         <label for="description" class="form-label">{{ __('Description') }}</label>
-                        <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+                        <textarea class="form-control" id="description" name="description" rows="3" autocomplete="off"></textarea>
                     </div>
 
                     <div class="mb-3">

--- a/resources/views/pages/departments/edit.twig
+++ b/resources/views/pages/departments/edit.twig
@@ -24,7 +24,7 @@
 
                     <div class="mb-3">
                         <label for="description" class="form-label">{{ __('Description') }}</label>
-                        <textarea class="form-control" id="description" name="description" rows="3">{{ department.description }}</textarea>
+                        <textarea class="form-control" id="description" name="description" rows="3" autocomplete="off">{{ department.description }}</textarea>
                     </div>
 
                     <div class="mb-3">


### PR DESCRIPTION
- Disables autocompletion (browser remembering things) in textareas
- Change the back button on `angeltypes?action=view&angeltype_id=X` to redirect to `/critertypes` instead of `angeltypes`